### PR TITLE
Updated getPosition to handle other stack variations and updated tests

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,15 +1,15 @@
 var getPosition = require('./modules/getPosition');
 
 module.exports = function(err) {
-  var stack = err.stack;
+  var stack = err.stack ? err.stack : '';
   var stackObject = stack.split('\n');
   var position = getPosition(stackObject);
   var filename = position.filename;
   var line = position.line;
   var row = position.row;
-  var message = err.message;
-  var type = err.type;
-
+  var splitMessage = err.message ? err.message.split('\n') : [''];
+  var message = splitMessage[splitMessage.length - 1];
+  var type = err.type ? err.type : err.name;
   var data = {
     filename: filename,
     line: line,
@@ -19,6 +19,5 @@ module.exports = function(err) {
     stack: stack,
     arguments: err.arguments
   };
-
   return data;
 };

--- a/lib/modules/getPosition.js
+++ b/lib/modules/getPosition.js
@@ -1,20 +1,36 @@
-var indexOfAll = require('./indexOfAll');
-
 module.exports = function (stackObject) {
-  var obj = stackObject[1].match(/\(.+?\)/g).pop();
-  var len = obj.length;
-  var indexes = indexOfAll(obj, ':');
-  var rowIndex = indexes.pop() + 1;
-  var lineIndex = indexes.pop() + 1;
-  var rowLength = len - rowIndex - 1;
-  var lineLength = len - lineIndex - rowLength - 2;
-  var row = obj.substring(rowIndex, rowIndex + rowLength);
-  var line = obj.substring(lineIndex, lineIndex + lineLength);
-  var filename = obj.substring(1, lineIndex - 1);
-
+  var filename, line, row;
+  // Because the JavaScript error stack has not yet been standardized,
+  // wrap the stack parsing in a try/catch for a soft fail if an
+  // unexpected stack is encountered.
+  try {
+    var filteredStack = stackObject
+      .filter(function (s) {
+        return /\(.+?\)$/.test(s);
+      });
+    var splitLine;
+    // For current Node & Chromium Error stacks
+    if(filteredStack.length > 0) {
+      splitLine = filteredStack[0]
+        .match(/(?:\()(.+?)(?:\))$/)[1]
+        .split(':');
+    // For older, future, or otherwise unexpected stacks
+    } else {
+      splitLine = stackObject[0]
+        .split(':');
+    }
+    var splitLength = splitLine.length;
+    filename = splitLine[splitLength - 3];
+    line = Number(splitLine[splitLength - 2]);
+    row = Number(splitLine[splitLength - 1]);
+  } catch(err) {
+    filename = '';
+    line = 0;
+    row = 0;
+  }
   return {
     filename: filename,
-    line: Number(line),
-    row: Number(row)
+    line: line,
+    row: row
   };
-}
+};

--- a/package.json
+++ b/package.json
@@ -19,5 +19,7 @@
   "bugs": {
     "url": "https://github.com/watilde/parse-error/issues"
   },
-  "homepage": "https://github.com/watilde/parse-error"
+  "homepage": "https://github.com/watilde/parse-error",
+  "dependencies": {},
+  "devDependencies": {}
 }

--- a/test/test-stacks/FIREFOX_ERROR_STACK.txt
+++ b/test/test-stacks/FIREFOX_ERROR_STACK.txt
@@ -1,0 +1,5 @@
+[
+  "something@file:///home/test/projects/parse-error/catch-error.js:3:12",
+  "window.onload@file:///home/test/projects/parse-error/catch-error.js:8:11",
+  ""
+]

--- a/test/test-stacks/NODE_ERROR_STACK.txt
+++ b/test/test-stacks/NODE_ERROR_STACK.txt
@@ -1,0 +1,12 @@
+[
+  "TypeError: anything is not a function",
+  "    at something (/home/test/projects/parse-error/catch-error.js:3:12)",
+  "    at Module._compile (module.js:556:32)",
+  "    at Object.Module._extensions..js (module.js:565:10)",
+  "    at Module.load (module.js:473:32)",
+  "    at tryModuleLoad (module.js:432:12)",
+  "    at Function.Module._load (module.js:424:3)",
+  "    at Module.runMain (module.js:590:10)",
+  "    at run (bootstrap_node.js:394:7)",
+  "    at startup (bootstrap_node.js:149:9)"
+]

--- a/test/test-stacks/OTHER_NODE_ERROR_STACK.txt
+++ b/test/test-stacks/OTHER_NODE_ERROR_STACK.txt
@@ -1,0 +1,15 @@
+[
+  "TypeError: ",
+  "/home/rondo/projects/parse-error/catch-error.js",
+  "anything is not a function",
+  "    at Object.<anonymous> (/home/test/projects/parse-error/catch-error.js:3:12)",
+  "    at Module._compile (module.js:541:32)",
+  "    at Object.devtoolCompileModule [as .js] (/home/test/.npm-global/lib/node_modules/devtool/lib/require-hook.js:32:14)",
+  "    at Module.load (module.js:456:32)",
+  "    at tryModuleLoad (module.js:415:12)",
+  "    at Function.Module._load (module.js:407:3)",
+  "    at Module.require (module.js:466:17)",
+  "    at require (internal/module.js:20:19)",
+  "    at EventEmitter.<anonymous> (/home/test/.npm-global/lib/node_modules/devtool/lib/preload.js:83:16)",
+  "    at emitOne (events.js:96:13)"
+]

--- a/test/test.js
+++ b/test/test.js
@@ -1,21 +1,87 @@
-var parseError = require('../lib/main');
+var assert = require('assert'),
+  fs = require('fs'),
+  path = require('path'),
+  parseError = require('../lib/main'),
+  getPosition = require('../lib/modules/getPosition');
+
+
+// 1. Check the getPosition module to make sure it properly handles common stack types
+
+process.stdout.write('\n1. Check getPosition module\n');
+
+var nodeChromiumErrorStack = JSON.parse(fs.readFileSync(path.join('test', 'test-stacks', 'NODE_ERROR_STACK.txt')));
+var firefoxErrorStack = JSON.parse(fs.readFileSync(path.join('test', 'test-stacks', 'FIREFOX_ERROR_STACK.txt')));
+var otherNodeErrorStack = JSON.parse(fs.readFileSync(path.join('test', 'test-stacks', 'OTHER_NODE_ERROR_STACK.txt')));
+
+var getPositionFixture = {
+  filename: 'home\/test\/projects\/parse-error\/catch-error\\.js',
+  line: 3,
+  row: 12
+};
+
+var fileNamePatt = new RegExp(getPositionFixture.filename);
+
+var nodeData = getPosition(nodeChromiumErrorStack);
+process.stdout.write('\nChecking getPosition with Node Error stack');
+assert(fileNamePatt.test(nodeData.filename));
+assert(getPositionFixture.line === nodeData.line);
+assert(getPositionFixture.row === nodeData.row);
+process.stdout.write(' - Success!\n');
+
+var otherNodeData = getPosition(otherNodeErrorStack);
+process.stdout.write('Checking getPosition with other Node Error stack');
+assert(fileNamePatt.test(otherNodeData.filename));
+assert(getPositionFixture.line === otherNodeData.line);
+assert(getPositionFixture.row === otherNodeData.row);
+process.stdout.write(' - Success!\n');
+
+var ffData = getPosition(firefoxErrorStack);
+process.stdout.write('Checking getPosition with Firefox Error stack');
+assert(fileNamePatt.test(ffData.filename));
+assert(getPositionFixture.line === ffData.line);
+assert(getPositionFixture.row === ffData.row);
+process.stdout.write(' - Success!\n');
+
+process.stdout.write('Checking getPosition with undefined stack');
+var badStackResult = getPosition(undefined);
+assert(typeof badStackResult === 'object');
+assert(typeof badStackResult.filename === 'string');
+assert(typeof badStackResult.line === 'number');
+assert(typeof badStackResult.row === 'number');
+process.stdout.write(' - Success!\n');
+
+// 2. check the output of parseError
 
 var fixture = {
-  line: 21,
+  line: 87,
   row: 1,
   message: 'nonExistentFunc is not defined',
-  type: 'not_defined'
+  type: 'ReferenceError'
 };
 
 process.on('uncaughtException', function(e) {
   var data = parseError(e);
 
-  if (fixture.line !== data.line) process.exit(1);
-  if (fixture.row !== data.row) process.exit(1);
-  if (fixture.message !== data.message) process.exit(1);
-  if (fixture.type !== data.type) process.exit(1);
+  process.stdout.write('\n2. Check parseError output\n');
 
-  process.exit(0);
+  process.stdout.write('\nChecking line');
+  assert(fixture.line === data.line);
+  process.stdout.write(' - Success!\n');
+
+  process.stdout.write('Checking row');
+  assert(fixture.row === data.row);
+  process.stdout.write(' - Success!\n');
+
+  process.stdout.write('Checking message');
+  assert(fixture.message === data.message);
+  process.stdout.write(' - Success!\n');
+
+  process.stdout.write('Checking type');
+  assert(fixture.type === data.type);
+  process.stdout.write(' - Success!\n');
+
+  process.stdout.write('\nAll tests successfully passed.\n\n');
+
 });
 
 nonExistentFunc();


### PR DESCRIPTION
I love your `parse-error` package, but in a production application of mine where I am using it as part of my error reporting package it began crashing the application. It turns out that the JavaScript error stack has not been standardized and new versions of Node have changed the stack in ways that the current version of `parse-error` can not adequately handle (I am currently running Node 6.5.0).

![screenshot at 2016-09-15 20 55 06](https://cloud.githubusercontent.com/assets/8548835/18572303/23b4f0dc-7b88-11e6-9a55-6502fccb25ff.png)

In the photo from my Node debugger, you can see the problem is with position 1 of the stack array. The `match()` failed to find a set of parenthesis and returned `null` which caused an error when `pop()` was called on the null value.

For the sake of my users I updated the package to handle the different variations I have encountered in Node plus the variation used in Firefox (because it is not standardized, we don't know if the stack will look more like Firefox's in the future, so it makes sense to be able to handle that as well as the Chromium variations used in Node). I also wrapped the `getPosition` functionality in a try/catch so that it soft-fails and won't crash applications if in a future version of Node another breaking change is made. I updated the tests to cover the updated functionality. Seeing that you had no npm dependencies, I added none myself and just stuck with vanilla JavaScript.

For the time being I will be shipping my forked version of the library to my users, but it would be greatly appreciated if you could merge these changes in and update the npm repo in the near future.

Thanks!
